### PR TITLE
[chord_diagram] optionally hide zero-width chords

### DIFF
--- a/chord_diagram.py
+++ b/chord_diagram.py
@@ -21,7 +21,7 @@ LW = 0.3
 
 def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
                   chordwidth=0.7, ax=None, colors=None, cmap=None, alpha=0.7,
-                  use_gradient=False, show=False,**kwargs):
+                  use_gradient=False, show=False, **kwargs):
     """
     Plot a chord diagram.
 
@@ -193,7 +193,7 @@ def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
 
         start, end = pos[(i, i)]
 
-        if mat[i,i]>0:
+        if mat[i, i] > 0:
             self_chord_arc(start, end, radius=1 - width - gap,
                            chordwidth=0.7*chordwidth, color=chord_colors[i],
                            alpha=alpha, ax=ax)
@@ -205,7 +205,7 @@ def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
 
             start1, end1 = pos[(i, j)]
             start2, end2 = pos[(j, i)]
-            if mat[i,j]>0 or mat[j,i]>0:
+            if mat[i, j] > 0 or mat[j, i] > 0:
                 chord_arc(start1, end1, start2, end2, radius=1 - width - gap,
                           chordwidth=chordwidth, color=colors[i], cend=cend,
                           alpha=alpha, ax=ax, use_gradient=use_gradient)

--- a/chord_diagram.py
+++ b/chord_diagram.py
@@ -21,7 +21,7 @@ LW = 0.3
 
 def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
                   chordwidth=0.7, ax=None, colors=None, cmap=None, alpha=0.7,
-                  use_gradient=False, show=False, **kwargs):
+                  use_gradient=False, show=False, show_zeros=True, **kwargs):
     """
     Plot a chord diagram.
 
@@ -54,6 +54,8 @@ def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
     use_gradient : bool, optional (default: False)
         Whether a gradient should be use so that chord extremities have the
         same color as the arc they belong to.
+    show_zeros : bool, optional (default: True)
+        Whether chords of zero-width should be shown.
     **kwargs : keyword arguments
         Available kwargs are "fontsize" and "sort" (either "size" or
         "distance"), "zero_entry_size" (in degrees, default: 0.5),
@@ -193,9 +195,10 @@ def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
 
         start, end = pos[(i, i)]
 
-        self_chord_arc(start, end, radius=1 - width - gap,
-                       chordwidth=0.7*chordwidth, color=colors[i],
-                       alpha=alpha, ax=ax)
+        if mat[i,i]>0 or show_zeros:
+            self_chord_arc(start, end, radius=1 - width - gap,
+                           chordwidth=0.7*chordwidth, color=colors[i],
+                           alpha=alpha, ax=ax)
 
         color = colors[i]
 
@@ -204,10 +207,10 @@ def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
 
             start1, end1 = pos[(i, j)]
             start2, end2 = pos[(j, i)]
-
-            chord_arc(start1, end1, start2, end2, radius=1 - width - gap,
-                      chordwidth=chordwidth, color=colors[i], cend=cend,
-                      alpha=alpha, ax=ax, use_gradient=use_gradient)
+            if mat[i,j]>0 or mat[j,i]>0 or show_zeros:
+                chord_arc(start1, end1, start2, end2, radius=1 - width - gap,
+                          chordwidth=chordwidth, color=colors[i], cend=cend,
+                          alpha=alpha, ax=ax, use_gradient=use_gradient)
 
     # add names if necessary
     if names is not None:

--- a/chord_diagram.py
+++ b/chord_diagram.py
@@ -21,7 +21,7 @@ LW = 0.3
 
 def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
                   chordwidth=0.7, ax=None, colors=None, cmap=None, alpha=0.7,
-                  use_gradient=False, show=False, show_zeros=True, **kwargs):
+                  use_gradient=False, show=False,**kwargs):
     """
     Plot a chord diagram.
 
@@ -54,8 +54,6 @@ def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
     use_gradient : bool, optional (default: False)
         Whether a gradient should be use so that chord extremities have the
         same color as the arc they belong to.
-    show_zeros : bool, optional (default: True)
-        Whether chords of zero-width should be shown.
     **kwargs : keyword arguments
         Available kwargs are "fontsize" and "sort" (either "size" or
         "distance"), "zero_entry_size" (in degrees, default: 0.5),
@@ -195,9 +193,9 @@ def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
 
         start, end = pos[(i, i)]
 
-        if mat[i,i]>0 or show_zeros:
+        if mat[i,i]>0:
             self_chord_arc(start, end, radius=1 - width - gap,
-                           chordwidth=0.7*chordwidth, color=colors[i],
+                           chordwidth=0.7*chordwidth, color=chord_colors[i],
                            alpha=alpha, ax=ax)
 
         color = colors[i]
@@ -207,7 +205,7 @@ def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
 
             start1, end1 = pos[(i, j)]
             start2, end2 = pos[(j, i)]
-            if mat[i,j]>0 or mat[j,i]>0 or show_zeros:
+            if mat[i,j]>0 or mat[j,i]>0:
                 chord_arc(start1, end1, start2, end2, radius=1 - width - gap,
                           chordwidth=chordwidth, color=colors[i], cend=cend,
                           alpha=alpha, ax=ax, use_gradient=use_gradient)


### PR DESCRIPTION
Hi! You seem to have the most recent/active fork of mpl_chord_diagram.

It worked out of the box for my problem in 2 min, thanks!

Since you don't have "issues", I'm communicating through a PR, I hope that's okay. 

So, while I decide whether to make another project of mine (gph82/mdciao) depend on mpl_chord_diagram (your fork or mine, also undecided), I noticed there's no option to turn off zero-width nodes, so I included one. 

If you don't like cluttering the signature, I was thinking perhaps to make it depend on whether the matrix is given as sparse or dense. Sparse triggers the "don't show zeros" option internally automatically. 

What do you think? 

![image](https://user-images.githubusercontent.com/7518004/98798416-2727e480-240e-11eb-8ab4-dd0fb6895908.png)

