### PR TITLE
color handling: control chord_color

### DIFF
--- a/chord_diagram.py
+++ b/chord_diagram.py
@@ -21,7 +21,7 @@ LW = 0.3
 
 def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
                   chordwidth=0.7, ax=None, colors=None, cmap=None, alpha=0.7,
-                  use_gradient=False, show=False, chord_colors=None, **kwargs):
+                  use_gradient=False, chord_colors=None, show=False, **kwargs):
     """
     Plot a chord diagram.
 
@@ -55,9 +55,6 @@ def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
     use_gradient : bool, optional (default: False)
         Whether a gradient should be use so that chord extremities have the
         same color as the arc they belong to.
-    show : bool, optional (default: False)
-        Whether the plot should be displayed immediately via an automatic call
-        to `plt.show()`.
     chord_colors : str, RGB tuple, list, optional (default: None)
         Specify color(s) to fill the chords differently from the arcs.
         When the keyword is not used, chord colors default to the colomap given
@@ -68,6 +65,9 @@ def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
          * a list of colors, e.g. ``["red","green","blue"]``, one per node.
            Each chord will get its color from its associated source node, or
            from both nodes if `use_gradient` is True.
+    show : bool, optional (default: False)
+        Whether the plot should be displayed immediately via an automatic call
+        to `plt.show()`.
     **kwargs : keyword arguments
         Available kwargs are "fontsize" and "sort" (either "size" or
         "distance"), "zero_entry_size" (in degrees, default: 0.5),

--- a/chord_diagram.py
+++ b/chord_diagram.py
@@ -48,18 +48,21 @@ def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
     colors : list, optional (default: from `cmap`)
         List of user defined colors or floats.
     cmap : str or colormap object (default: viridis)
-        Colormap to use.
+        Colormap that will be used to color the arcs and chords by default.
+        See `chord_colors` to use different colors for chords.
     alpha : float in [0, 1], optional (default: 0.7)
         Opacity of the chord diagram.
     use_gradient : bool, optional (default: False)
         Whether a gradient should be use so that chord extremities have the
         same color as the arc they belong to.
     chord_colors : str, RGB tuple, list, optional (default: None)
-        Default (None) is to use the same values as 'colors'. Optionally,
-        one can specify different color(s) here:
-         * "red", all chords have this color
-         * [1, 0, 0] : all chords have this RGB color (red)
-         * ["red","green","blue"] : each chord gets one color of this list.
+        Specify color(s) to fill the chords differently from the arcs.
+        When the keyword is not used, chord colors default to the colomap given
+        by `colors`.
+        Possible values for `chord_colors` are:
+         * a single color or RGB tuple, e.g. "red" or ``(1, 0, 0)``; all chords
+           will have this color
+         * a list of colors, e.g. ``["red","green","blue"]`` : each chord gets one color of this list.
          The list has to be of the same length as the number
          of chords to plot, which is the number of nonzero elements of mat
          ([ii,jj] and [jj,ii] count as one nonzero element. The list
@@ -86,7 +89,7 @@ def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
     # mat[i, j]:  i -> j
     num_nodes = mat.shape[0]
 
-    # set entries for zero entries that have a nonzero reciprocal
+    # set entry size for zero entries that have a nonzero reciprocal
     min_deg  = kwargs.get("zero_entry_size", 0.5)
     min_deg *= mat.sum() / (360 - num_nodes*pad)
 
@@ -146,7 +149,7 @@ def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
         raise ValueError("`colors` should be a list.")
 
     if chord_colors is None:
-       chord_colors=colors
+       chord_colors = colors
     else:
         try:
             chord_colors = [ColorConverter.to_rgb(chord_colors)]*num_nodes

--- a/chord_diagram.py
+++ b/chord_diagram.py
@@ -164,6 +164,7 @@ def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
     nodePos = []
     start = 0
 
+    # compute all values and optionally apply sort
     for i in range(num_nodes):
         end = start + y[i]
         arc.append((start, end))
@@ -206,30 +207,37 @@ def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
 
         start = end + pad
 
+    # plot
     for i in range(len(x)):
+        color = colors[i]
+
+        # plot the arcs
         start, end = arc[i]
 
-        ideogram_arc(start=start, end=end, radius=1.0, color=colors[i],
+        ideogram_arc(start=start, end=end, radius=1.0, color=color,
                      width=width, alpha=alpha, ax=ax)
 
         start, end = pos[(i, i)]
 
+        chord_color = chord_colors[i]
+
+        # plot self-chords
         if mat[i, i] > 0:
             self_chord_arc(start, end, radius=1 - width - gap,
-                           chordwidth=0.7*chordwidth, color=colors[i],
+                           chordwidth=0.7*chordwidth, color=chord_color,
                            alpha=alpha, ax=ax)
 
-        color = colors[i]
-
+        # plot all other chords
         for j in range(i):
             cend = chord_colors[j]
 
             start1, end1 = pos[(i, j)]
             start2, end2 = pos[(j, i)]
+
             if mat[i, j] > 0 or mat[j, i] > 0:
                 chord_arc(
                     start1, end1, start2, end2, radius=1 - width - gap,
-                    chordwidth=chordwidth, color=chord_colors[i], cend=cend,
+                    chordwidth=chordwidth, color=chord_color, cend=cend,
                     alpha=alpha, ax=ax, use_gradient=use_gradient)
 
     # add names if necessary

--- a/chord_diagram.py
+++ b/chord_diagram.py
@@ -21,7 +21,7 @@ LW = 0.3
 
 def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
                   chordwidth=0.7, ax=None, colors=None, cmap=None, alpha=0.7,
-                  use_gradient=False, show=False, **kwargs):
+                  use_gradient=False, show=False, chord_colors=None, **kwargs):
     """
     Plot a chord diagram.
 
@@ -54,6 +54,16 @@ def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
     use_gradient : bool, optional (default: False)
         Whether a gradient should be use so that chord extremities have the
         same color as the arc they belong to.
+    chord_colors : str, RGB tuple, list, optional (default: None)
+        Default (None) is to use the same values as 'colors'. Optionally,
+        one can specify different color(s) here:
+         * "red", all chords have this color
+         * [1, 0, 0] : all chords have this RGB color (red)
+         * ["red","green","blue"] : each chord gets one color of this list.
+         The list has to be of the same length as the number
+         of chords to plot, which is the number of nonzero elements of mat
+         ([ii,jj] and [jj,ii] count as one nonzero element. The list
+         entries can be themselves RGB tuples
     **kwargs : keyword arguments
         Available kwargs are "fontsize" and "sort" (either "size" or
         "distance"), "zero_entry_size" (in degrees, default: 0.5),
@@ -135,6 +145,14 @@ def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
     else:
         raise ValueError("`colors` should be a list.")
 
+    if chord_colors is None:
+       chord_colors=colors
+    else:
+        try:
+            chord_colors = [ColorConverter.to_rgb(chord_colors)]*num_nodes
+        except ValueError:
+            assert len(chord_colors)==num_nodes, "If you pass a list of chord_colors, the list has to be of len %u"%num_nodes
+
     # find position for each start and end
     y = x / np.sum(x).astype(float) * (360 - pad*len(x))
 
@@ -207,7 +225,7 @@ def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
             start2, end2 = pos[(j, i)]
             if mat[i, j] > 0 or mat[j, i] > 0:
                 chord_arc(start1, end1, start2, end2, radius=1 - width - gap,
-                          chordwidth=chordwidth, color=colors[i], cend=cend,
+                          chordwidth=chordwidth, color=chord_colors[i], cend=cend,
                           alpha=alpha, ax=ax, use_gradient=use_gradient)
 
     # add names if necessary

--- a/chord_diagram.py
+++ b/chord_diagram.py
@@ -394,8 +394,8 @@ def ideogram_arc(start, end, radius=1., width=0.2, color="r", alpha=0.7,
 
     if ax is not None:
         path  = Path(verts, codes)
-        patch = patches.PathPatch(path, facecolor=tuple(color) + (alpha,),
-                                  edgecolor=tuple(color) + (alpha,), lw=LW)
+        patch = patches.PathPatch(path, facecolor=color, alpha=alpha,
+                                  edgecolor=color, lw=LW)
         ax.add_patch(patch)
 
     return verts, codes
@@ -519,8 +519,8 @@ def chord_arc(start1, end1, start2, end2, radius=1.0, pad=2, chordwidth=0.7,
             gradient(points[0], points[1], min_angle, color, cend, meshgrid,
                      patch, ax, alpha)
         else:
-            patch = patches.PathPatch(path, facecolor=tuple(color)+(alpha,),
-                                      edgecolor=tuple(color)+(alpha,), lw=LW)
+            patch = patches.PathPatch(path, facecolor=color, alpha=alpha,
+                                      edgecolor=color, lw=LW)
 
             idx = 16
 
@@ -549,8 +549,8 @@ def self_chord_arc(start, end, radius=1.0, chordwidth=0.7, ax=None,
 
     if ax is not None:
         path  = Path(verts, codes)
-        patch = patches.PathPatch(path, facecolor=tuple(color)+(alpha,),
-                                  edgecolor=tuple(color)+(alpha,), lw=LW)
+        patch = patches.PathPatch(path, facecolor=color, alpha=alpha,
+                                  edgecolor=color, lw=LW)
         ax.add_patch(patch)
 
     return verts, codes

--- a/chord_diagram.py
+++ b/chord_diagram.py
@@ -62,11 +62,9 @@ def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
         Possible values for `chord_colors` are:
          * a single color or RGB tuple, e.g. "red" or ``(1, 0, 0)``; all chords
            will have this color
-         * a list of colors, e.g. ``["red","green","blue"]`` : each chord gets one color of this list.
-         The list has to be of the same length as the number
-         of chords to plot, which is the number of nonzero elements of mat
-         ([ii,jj] and [jj,ii] count as one nonzero element. The list
-         entries can be themselves RGB tuples
+         * a list of colors, e.g. ``["red","green","blue"]``, one per node.
+           Each chord will get its color from its associated source node, or
+           from both nodes if `use_gradient` is True.
     **kwargs : keyword arguments
         Available kwargs are "fontsize" and "sort" (either "size" or
         "distance"), "zero_entry_size" (in degrees, default: 0.5),
@@ -152,9 +150,11 @@ def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
        chord_colors = colors
     else:
         try:
-            chord_colors = [ColorConverter.to_rgb(chord_colors)]*num_nodes
+            chord_colors = [ColorConverter.to_rgb(chord_colors)] * num_nodes
         except ValueError:
-            assert len(chord_colors)==num_nodes, "If you pass a list of chord_colors, the list has to be of len %u"%num_nodes
+            assert len(chord_colors) == num_nodes, \
+                "If `chord_colors` is a list of colors, it should include " \
+                "one color per node (here {} colors).".format(num_nodes)
 
     # find position for each start and end
     y = x / np.sum(x).astype(float) * (360 - pad*len(x))
@@ -222,14 +222,15 @@ def chord_diagram(mat, names=None, order=None, width=0.1, pad=2., gap=0.03,
         color = colors[i]
 
         for j in range(i):
-            cend = colors[j]
+            cend = chord_colors[j]
 
             start1, end1 = pos[(i, j)]
             start2, end2 = pos[(j, i)]
             if mat[i, j] > 0 or mat[j, i] > 0:
-                chord_arc(start1, end1, start2, end2, radius=1 - width - gap,
-                          chordwidth=chordwidth, color=chord_colors[i], cend=cend,
-                          alpha=alpha, ax=ax, use_gradient=use_gradient)
+                chord_arc(
+                    start1, end1, start2, end2, radius=1 - width - gap,
+                    chordwidth=chordwidth, color=chord_colors[i], cend=cend,
+                    alpha=alpha, ax=ax, use_gradient=use_gradient)
 
     # add names if necessary
     if names is not None:


### PR DESCRIPTION
Here's another suggestion for controlling chord color. I have found it useful in my plots (see example below)

As before it's a suggestion ;)  All these inputs would work:
```
mpl_chord_diagram.chord_diagram(C, 
                                chord_colors="red",
                                #chord_colors=[1, 0, 0],
                                #chord_colors=["red","green","blue"],
                                #chold_colors=[[1, 0, 0],
                                              [0, 1, 0],
                                              [0, 0, 1]],
                               );
```
Here's an example that I find visually appealing:

![image](https://user-images.githubusercontent.com/7518004/100454765-d8d93d80-30bd-11eb-865f-b22bdd6f6136.png)

Next up: text label placing (probably an va="middle" has to be set somewhere
